### PR TITLE
`ruok` command is idempotent

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,8 @@
 
 - name: Check that zookeeper started correctly
   shell: echo ruok | nc 127.0.0.1 2181
+  always_run: True
+  changed_when: False
   register: zk_ruok
 
 - assert:


### PR DESCRIPTION
Since `ruok` command is invoked by shell module, we need to make it not
emit the changed status. That does not cause any problem because it is
an idempotent operation.

Signed-off-by: Ryo Tagami rtagami@airstrip.jp
