### PR TITLE
Make use of midonet repos and get rid of OpenJDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,6 @@ install:
   - sudo pip install ansible
   # Add ansible.cfg to pick up roles path.
   - "{ echo '[defaults]'; echo 'roles_path = ../'; } >> ansible.cfg"
-  # Install required ansible roles
-  - ansible-galaxy install geerlingguy.java
-  - ansible-galaxy install abelboldu.midonet-repos
-
 
 script:
 # Check the role/playbook's syntax.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Dependencies
 ------------
 
 Java ( geerlingguy.java )
-Midonet repositories ( abelboldu.midonet-repos )
+Midonet repositories ( ansible-midonet-repo )
 
 Example Playbook
 ----------------
@@ -41,7 +41,7 @@ Example Playbook
 ```
 hosts: zookeeper
   roles:
-    - role: abelboldu.zookeeper
+    - role: ansible-zookeeper
       zookeeper_hosts: '{{ groups["zookeeper"] }}'
 ```
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,5 +19,5 @@ galaxy_info:
   - database
 
 dependencies: 
-  - { role: abelboldu.midonet-repos }
-  - { role: geerlingguy.java }
+  - { role: ansible-midonet-repo }
+

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -3,10 +3,9 @@
 - name: Install EPEL repo
   yum: name="epel-release" state=present
 
-- name: Install Zookeeper (RedHat7)
+- name: Install Zookeeper
   yum: name={{ item }} state=present
   with_items:
-    - java-1.7.0-openjdk-headless
     - zookeeper
     - nmap-ncat
     - zkdump

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,3 +1,2 @@
 ---
-- src: geerlingguy.java
-- src: abelboldu.midonet-repos
+- src: 'https://github.com/midonet/ansible-midonet-repo'

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -3,21 +3,14 @@
 - hosts: zookeeper
   remote_user: root
   become: True
-  tasks:
-    - name: Installing repo for Java 8 in Ubuntu
-      apt_repository: repo='ppa:openjdk-r/ppa'
-      when: "ansible_distribution_release == 'trusty'"
 
 - hosts: zookeeper
   remote_user: root
   become: True
   roles:
-    - role: geerlingguy.java
-      when: "ansible_os_family == 'Debian'"
-      java_packages:
-        - openjdk-8-jdk
-    - role: abelboldu.midonet-repos
-      midonet_version: current
+    - role: ansible-midonet-repo
+      midonet_version: 5.2
+      mem: False
     - role: ansible-zookeeper
       zookeeper_hosts: '{{ groups["zookeeper"] }}'
   post_tasks:


### PR DESCRIPTION
ansible-midonet-repo now takes care of setting up
OpenJDK 8 PPA on trusty now (and the rest of supported distros already provide
it by default).
