### PR TITLE
Don't Create JAVA_HOME Symlink

### DIFF
--- a/tasks/packages_debian.yml
+++ b/tasks/packages_debian.yml
@@ -6,5 +6,10 @@
     state: present
   with_items:
     - 'netcat-openbsd'
-    - 'zkdump'
     - 'zookeeperd'
+
+- name: Install zkdump
+  apt:
+    name: 'zkdump'
+    state: present
+  when: zookeeper_install_zkdump|default(False)

--- a/tasks/packages_redhat.yml
+++ b/tasks/packages_redhat.yml
@@ -7,29 +7,14 @@
 
 - name: Install Zookeeper
   yum:
-    name: 'zookeeper'
-    state: present
-  register: zookeeper_zookeeper_package
-
-- name: Install Zookeeper
-  yum:
     name: '{{ item }}'
     state: present
   with_items:
     - 'nmap-ncat'
-    - 'zkdump'
+    - 'zookeeper'
 
-- name: Force systemd daemon reload
-  command: 'systemctl daemon-reload'
-  when: zookeeper_zookeeper_package|changed
-
-- name: Create /usr/java directory
-  file:
-    path: '/usr/java'
-    state: directory
-
-- name: Create JAVA_HOME symbolic link
-  file:
-    src: '/etc/alternatives/jre_openjdk'
-    dest: '/usr/java/default'
-    state: link
+- name: Install zkdump
+  yum:
+    name: 'zkdump'
+    state: present
+  when: zookeeper_install_zkdump|default(False)


### PR DESCRIPTION
With the newly released zookeeper-3.4.8-1.x86_64.rpm for CentOS 7, there
is no need to create the JAVA_HOME symbolic link anymore.  Plus, zkdump
is not necessary for every circumstances, so install it conditionally.

Signed-off-by: Ryo Tagami rtagami@airstrip.jp
