### PR TITLE
zoo.cfg template changes for network interface settings

### DIFF
--- a/templates/zoo.cfg
+++ b/templates/zoo.cfg
@@ -20,7 +20,7 @@ clientPort=2181
 # The fist port is used by followers to connect to the leader
 # The second one is used for leader election
 {% for host in zookeeper_hosts %}
-server.{{ hostvars[host]['zookeeper_myid'] }}={{ hostvars[host]['ansible_default_ipv4']['address'] }}:2888:3888
+server.{{ hostvars[host]['zookeeper_myid'] }}={{ hostvars[host]['ansible_host'] }}:2888:3888
 {% endfor %}
 
 # ZooKeeper auto purge feature retains the most recent snapshots and


### PR DESCRIPTION
In some environments default_ipv4 is not the same address over which zookeeper cluster nodes interact.