### PR TITLE
Fix hostvars

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+zookeeper_hosts: ["localhost"]

--- a/templates/zoo.cfg
+++ b/templates/zoo.cfg
@@ -20,7 +20,7 @@ clientPort=2181
 # The fist port is used by followers to connect to the leader
 # The second one is used for leader election
 {% for host in zookeeper_hosts %}
-server.{{ hostvars[host]['zookeeper_myid'] }}={{ hostvars[host]['ansible_host'] }}:2888:3888
+server.{{ hostvars[host]['zookeeper_myid'] }}={{ hostvars[host][ansible_host] | default(inventory_hostname) }}:2888:3888
 {% endfor %}
 
 # ZooKeeper auto purge feature retains the most recent snapshots and

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -13,4 +13,4 @@
   post_tasks:
     - name: Check id
       debug:
-        var: hostvars['ubuntu']['myid']
+        var: hostvars['{{ inventory_hostname }}']['zookeeper_myid']


### PR DESCRIPTION
`ansible_host` var does not exist when the connection is local (like in the travis case), so make use of the inventory hostname as default.